### PR TITLE
Adds formatted error logging when debug is turned on

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,6 +82,9 @@ exports.register = function (server, options, next) {
                 }, function(err, result){
 
                     if(err){
+                        if (debug) {
+                            internals.log('error', err.formatted);
+                        }
                         return internals.error(reply, err);
                     }
 


### PR DESCRIPTION
Using this on a company project and noticed that compilation error messaging when debug is set to true doesn't give detailed information on where the error stems from. This adds that! Hoping this can be merged in soon so we can update that in our project.