### PR TITLE
Add support for multiple registrations per server

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,6 +163,7 @@ exports.register = function (server, options, next) {
 };
 
 exports.register.attributes = {
+    multiple: true,
     dependencies: 'inert',
     pkg: require('./package.json')
 };


### PR DESCRIPTION
Making a PR to fix #12.  I use `hapi-sass` under multiple plugins, defining unique routes within each plugin to their own sass files.  After looking through the code, I didn't see any glaring conflicts from multiple instances running, and it works locally in testing.