### PR TITLE
Add support for node-sass functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # hapi-sass
 
-A Hapi.js plugin for compiling and serving Sass stylesheets using [node-sass](https://github.com/andrew/node-sass). This is a port of their express middleware to a hapi.js plugin. 
+A Hapi.js plugin for compiling and serving Sass stylesheets using [node-sass](https://github.com/andrew/node-sass). This is a port of their express middleware to a hapi.js plugin.
 
 ### Overview
 
-This plugin will create a single (configurable) route on the server that will respond to requests for css files. 
+This plugin will create a single (configurable) route on the server that will respond to requests for css files.
 
-The plugin will map the request to a sass file in the configured `src` directory. The plugin will then try to just serve an existing, compiled `.css` file in the configured `dest` directory. If the file does not exist, or is older than the sass file, it will re-compile, write the file back to disk and respond with the contents back to the requestor. 
+The plugin will map the request to a sass file in the configured `src` directory. The plugin will then try to just serve an existing, compiled `.css` file in the configured `dest` directory. If the file does not exist, or is older than the sass file, it will re-compile, write the file back to disk and respond with the contents back to the requestor.
 
 
 ### Example usage:
@@ -32,6 +32,7 @@ var options = {
     includePaths: ['./example/vendor/sass'],
     outputStyle: 'nested',
     sourceComments: true,
+    functions: require('./functions'),
     srcExtension: 'scss'
 };
 
@@ -48,7 +49,7 @@ server.register([Inert, {
 );
 ```
 
-See the `example/` folder for more. 
+See the `example/` folder for more.
 
 ### Options:
 
@@ -57,8 +58,8 @@ See the `example/` folder for more.
 * `src`: the directory to find the requested `.sass` file. Defaults to `./lib/sass`
 * `srcExtension`: the extension of the requested `.sass` file. Defaults to `scss`
 * `dest`: the destination directory to write compiled `.css` files. Defaults to `./public/css`
-* `routePath`: the route to register with hapijs. Defaults to `/css/{file}.css`. The `{file}` portion of the string is currently significant. It's used as a request parameter. 
+* `routePath`: the route to register with hapijs. Defaults to `/css/{file}.css`. The `{file}` portion of the string is currently significant. It's used as a request parameter.
 * `outputStyle`: [parameter for node-sass](https://github.com/sass/node-sass#outputstyle). Defaults to `compressed`
 * `sourceComments`: [parameter for node-sass](https://github.com/sass/node-sass#sourcecomments). Defaults to `false`.
+* `functions`: [parameter for node-sass](https://github.com/sass/node-sass#functions--v300---experimental) to support custom functions. Defaults to an empty object.  
 * `includePaths`: [parameter for node-sass](https://github.com/sass/node-sass#includepaths). Defaults to `[]`.
- 

--- a/example/functions.js
+++ b/example/functions.js
@@ -1,0 +1,16 @@
+'use strict'
+
+let sass = require('node-sass');
+
+module.exports = {
+    'headings($from: 0, $to: 6)': function(from, to) {
+        var i, f = from.getValue(), t = to.getValue(),
+            list = new sass.types.List(t - f + 1);
+
+        for (i = f; i <= t; i++) {
+            list.setValue(i - f, new sass.types.String('h' + i));
+        }
+
+        return list;
+    }
+}

--- a/example/sass/style.scss
+++ b/example/sass/style.scss
@@ -15,3 +15,5 @@ nav {
     text-decoration: none;
   }
 }
+
+#{headings(2,5)} { color: #08c; }

--- a/example/server.js
+++ b/example/server.js
@@ -15,7 +15,7 @@ var Inert = require('inert');
 var server = new Hapi.Server();
 server.connection({ port: 1337 });
 
-var options = {
+let options = {
     src: './sass',
     dest: './css',
     force: true,
@@ -24,6 +24,7 @@ var options = {
     includePaths: ['./vendor/sass'],
     outputStyle: 'nested',
     sourceComments: true,
+    functions: require('./functions'),
     srcExtension: 'scss'
 };
 

--- a/index.js
+++ b/index.js
@@ -84,6 +84,7 @@ exports.register = function (server, options, next) {
                     includePaths: [sassDir].concat(settings.includePaths || []),
                     imagePath: settings.imagePath,
                     outputStyle: settings.outputStyle,
+                    functions: settings.functions,
                     sourceComments: settings.sourceComments
                 }, function (err, result) {
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-sass",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "A Hapi.js plugin for compiling and serving Sass stylesheets",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- functions is now an option you can pass to Hapi-sass. See:
  https://github.com/sass/node-sass#functions--v300---experimental

Todo: 
- [x] Add option to documentation
