### PR TITLE
Fixed problem with relativeTo

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ exports.register = function (server, options, next) {
     server.route({
         method: 'GET',
         path: settings.routePath,
+        config: { files: { relativeTo: './' } },
         handler: function (request, reply) {
 
             var cssPath = join(dest, request.params.file + '.css'),


### PR DESCRIPTION
If hapi-sass is added to a connection that uses the relativeTo, such as:

```javascript
routes: {
        files: {
            relativeTo: Path.join(__dirname, "../content")
        }
    }
```

Then hapi-sass returns a 404 for all but the first request when `force == false`.

This is because of index.js:156 `reply.file(cssPath);`. This code assumes that relativeTo is the current path. To fix, just override the `relativeTo` value for the hapi-sass route. 